### PR TITLE
Sets default night light config

### DIFF
--- a/material/overlay/common/frameworks/base/core/res/res/values/integers.xml
+++ b/material/overlay/common/frameworks/base/core/res/res/values/integers.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources>
+    <integer name="config_defaultNightDisplayAutoMode">0</integer>
+    <integer name="config_defaultNightDisplayCustomEndTime">21600000</integer>
+    <integer name="config_defaultNightDisplayCustomStartTime">79200000</integer>
+    <integer name="config_defaultNightMode">1</integer>
+    <integer name="config_nightDisplayColorTemperatureDefault">2850</integer>
+    <integer name="config_nightDisplayColorTemperatureMax">4082</integer>
+    <integer name="config_nightDisplayColorTemperatureMin">2596</integer>
+</resources>

--- a/material/overlay/common/frameworks/base/core/res/res/values/integers.xml
+++ b/material/overlay/common/frameworks/base/core/res/res/values/integers.xml
@@ -20,7 +20,7 @@
     <integer name="config_defaultNightDisplayAutoMode">0</integer>
     <integer name="config_defaultNightDisplayCustomEndTime">21600000</integer>
     <integer name="config_defaultNightDisplayCustomStartTime">79200000</integer>
-    <integer name="config_defaultNightMode">1</integer>
+    <integer name="config_defaultNightMode">0</integer>
     <integer name="config_nightDisplayColorTemperatureDefault">2850</integer>
     <integer name="config_nightDisplayColorTemperatureMax">4082</integer>
     <integer name="config_nightDisplayColorTemperatureMin">2596</integer>


### PR DESCRIPTION
Sets properly time when night light should be enabled/disabled + sets automode on by default.